### PR TITLE
Update dotnet-args build to use .NET SDK 7.0.101

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup net7.0
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: "7.0.100"
+          dotnet-version: "7.0.101"
       - name: Run dotnet --info
         run: dotnet --info
       - uses: actions/checkout@v3.1.0


### PR DESCRIPTION
Closes #48
